### PR TITLE
Fixed wrong encumberance handicap for initiative.

### DIFF
--- a/app/models/rule_set.rb
+++ b/app/models/rule_set.rb
@@ -205,7 +205,7 @@ class RuleSet < ActiveRecord::Base
           {abbr: 'speed_2', name: 'Laufweg 2', formula: 'speed_buff+speed*ath/40-encumberance', order: 11},
 
           # Initiative
-          {abbr: 'initiative', name: 'Initiative', formula: 'sch/5.0+initiative_roll-encumberance*4', order: 10},
+          {abbr: 'initiative', name: 'Initiative', formula: 'sch/5.0+initiative_roll-encumberance*2', order: 10},
       ]
       required_formulas.each do |req|
         if formula_by_abbr(req[:abbr]).nil?


### PR DESCRIPTION
Encumberance handicap for initiative should be 2 as stated in the excel file and noted in the pdf. Please note the pdf export is already adding only `2 * char.encumberance` to calculate the raw value.

https://github.com/Oromis/morrowind/blob/7a35aaf0aa2e40b1b49a85484a263f4f541e87be/app/views/characters/export.pdf.prawn#L232